### PR TITLE
Fix typos in setup-smt-switch.sh that cause build failures

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -27,12 +27,12 @@ die () {
     exit 1
 }
 
-WITH_BOOLECOR=default
+WITH_BOOLECTOR=default
 WITH_MSAT=default
 WITH_YICES2=default
 CONF_OPTS=""
 WITH_PYTHON=default
-cvc5_home=defaultt
+cvc5_home=default
 
 while [ $# -gt 0 ]
 do


### PR DESCRIPTION
## Summary
Fixed two critical typos in `contrib/setup-smt-switch.sh` that were causing the SMT-Sweep build to fail.

## Changes Made
- Line 30: `WITH_BOOLECOR=default` → `WITH_BOOLECTOR=default` (missing 'T')
- Line 35: `cvc5_home=defaultt` → `cvc5_home=default` (extra 't')

## Root Cause Analysis
These typos caused cascading build failures:

1. **Unary operator error**: The undefined `$WITH_BOOLECTOR` variable caused a shell error at line 80: `./contrib/setup-smt-switch.sh: line 80: [: =: unary operator expected`

2. **Missing dependencies**: The incorrect `cvc5_home` value prevented the condition `if [ $cvc5_home = default ]` from being true, so `setup-cvc5.sh` was never executed

3. **CMake configuration failure**: Without `setup-cvc5.sh` running, the required POLYLIB libraries (`libpicpoly.a`, `libpicpolyxx.a`) were missing, causing CMake to fail with: `Could not find POLYLIB using the following names: libpicpoly.a`

## Test Plan
- [x] Fixed the typos in the setup script
- [x] Verified the script now executes without shell errors
- [x] Confirmed that all required libraries are properly downloaded and available

With these fixes, the build process should complete successfully without the dependency errors.